### PR TITLE
Refactor CLI and workflows for flexible input and release processes

### DIFF
--- a/.changelog-config.yaml
+++ b/.changelog-config.yaml
@@ -80,11 +80,11 @@ commit_classifiers:
   - action: SummaryRegexMatch
     category: Updates
     kwargs:
-      pattern: (?i)^(?:update|change|rename|remove|delete|improve|refactor|chg|modif)[^\n]*$
+      pattern: (?i)^(?:update|change|rename|remove|delete|improve|chg|modif)[^\n]*$
   - action: SummaryRegexMatch
     category: Fixes
     kwargs:
-      pattern: (?i)^(?:fix)[^\n]*$
+      pattern: (?i)^(?:fix|refactor)[^\n]*$
   - action:
     category: Other
 

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -1,10 +1,13 @@
 name: Build Python Package
 
 on:
-  push:
-    tags-ignore:
-      - v*
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout. Otherwise, uses the default branch.
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -12,6 +12,7 @@ jobs:
       contents: write
     outputs:
       build_package: ${{ steps.bump-version.outputs.build_package }}
+      tag_name: ${{ steps.bump-version.outputs.tag_name }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -33,7 +34,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          python -m pip install bump-my-version
+          uv pip install bump-my-version
 
       - name: Generate changelog and release hint
         id: changelog
@@ -52,17 +53,8 @@ jobs:
               bump-my-version bump --allow-dirty --verbose "$RELEASE_KIND"
               git push
               git push --tags
+              echo "tag_name=${bump-my-version show current_version}" >> $GITHUB_OUTPUT
               echo "build_package=true" >> $GITHUB_OUTPUT
-              ;;
-            dev)
-              echo "Intentionally not bumping version for dev release"
-              echo "build_package=false" >> $GITHUB_OUTPUT
-              # to build a dev release
-              # bump-my-python bump --allow-dirty --verbose --no-commit --no-tag
-              # echo "build_package=true" >> $GITHUB_OUTPUT
-              ;;
-            no-release)
-              echo "build_package=false" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "build_package=false" >> $GITHUB_OUTPUT
@@ -78,3 +70,5 @@ jobs:
       id-token: write
       packages: write
     uses: ./.github/workflows/build-python.yaml
+    with:
+      ref: ${{ needs.bump-version.outputs.tag_name }}

--- a/.github/workflows/publish-docs-preview.yaml
+++ b/.github/workflows/publish-docs-preview.yaml
@@ -11,7 +11,7 @@ on:
 concurrency: preview-${{ github.ref }}
 
 jobs:
-  publish-docs:
+  publish-preview-docs:
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -1,6 +1,12 @@
 name: Release to GitHub
 on:
-  workflow_call: {} # This workflow requires the artifacts from build-python.yaml
+  workflow_call:
+    inputs:
+      ref:
+        description: The branch, tag or SHA to checkout. Otherwise, uses the default branch.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   release:
@@ -22,7 +28,7 @@ jobs:
       - name: release-notes
         uses: callowayproject/action-changelog-to-releasenotes@main
         with:
-          target-version: ${GITHUB_REF#refs/tags/}
+          target-version: ${{ inputs.ref }}
 
       - name: Download packages built by build-and-inspect-python-package
         uses: actions/download-artifact@v4
@@ -34,5 +40,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          tag_name: ${GITHUB_REF#refs/tags/}
+          tag_name: ${{ inputs.ref }}
           body_path: release-notes.md

--- a/project_forge/cli.py
+++ b/project_forge/cli.py
@@ -8,6 +8,7 @@ from click.core import Context
 
 from project_forge import __version__
 from project_forge.core.io import parse_file
+from project_forge.core.urls import parse_git_url
 from project_forge.ui.defaults import return_defaults
 from project_forge.ui.terminal import ask_question
 
@@ -28,7 +29,7 @@ def cli(ctx: Context) -> None:
 @cli.command()
 @click.argument(
     "composition",
-    type=click.Path(exists=True, dir_okay=False, file_okay=True, resolve_path=True, path_type=Path),
+    type=str,
 )
 @click.option(
     "--use-defaults",
@@ -64,7 +65,7 @@ def cli(ctx: Context) -> None:
     help="The key-value pairs added to the initial context. Great for providing answers to composition questions.",
 )
 def build(
-    composition: Path,
+    composition: str,
     use_defaults: bool,
     output_dir: Path,
     data_file: Optional[Path] = None,
@@ -72,6 +73,9 @@ def build(
 ):
     """Build a project from a composition and render it to a directory."""
     from project_forge.commands.build import build_project
+
+    parsed_url = parse_git_url(composition)
+    composition_path = Path(parsed_url.full_path)
 
     initial_context: dict[str, Any] = {"output_dir": output_dir.resolve()}
     if data_file:
@@ -84,7 +88,7 @@ def build(
     ui_function = return_defaults if use_defaults else ask_question
 
     build_project(
-        composition,
+        composition_path,
         output_dir=output_dir,
         ui_function=ui_function,
         initial_context=initial_context,


### PR DESCRIPTION
### Description

This pull request includes the following:

1. **Refactored CLI**: Updated the `composition` argument in the `build` command to accept git URLs instead of file paths. The parsing logic now extracts the file path from the URL, increasing flexibility for input handling.
2. **Workflow Enhancements**: Improved release management by allowing workflows to accept a reference (ref) input, renamed jobs for better readability, fixed pip command, and added outputs like `tag_name` for clearer release workflows.

### Checklist

- [ ] Tests
- [ ] Documentation

### Additional context

N/A